### PR TITLE
Use a copy of Django's available_attrs function to only override the attributes that exist when using the functors.wraps decorator.

### DIFF
--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -5,10 +5,6 @@ import time
 from uuid import uuid4
 
 try:
-    from functools import wraps
-except ImportError:
-    from django.utils.functional import wraps  # Python 2.3, 2.4 fallback.
-try:
     from hashlib import md5
 except ImportError:
     from md5 import md5
@@ -16,6 +12,7 @@ except ImportError:
 import localstore
 import signals
 from johnny import settings
+from johnny.decorators import wraps, available_attrs
 from transaction import TransactionManager
 
 import django
@@ -157,7 +154,7 @@ def get_tables_for_query11(query):
 def timer(func):
     times = []
 
-    @wraps(func)
+    @wraps(func, assigned=available_attrs(func))
     def foo(*args, **kwargs):
         t0 = time.time()
         ret = func(*args, **kwargs)
@@ -324,7 +321,7 @@ class QueryCacheBackend(object):
         from django.db.models.sql.constants import MULTI
         from django.db.models.sql.datastructures import EmptyResultSet
 
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun(cls, *args, **kwargs):
             if args:
                 result_type = args[0]
@@ -381,7 +378,7 @@ class QueryCacheBackend(object):
         return newfun
 
     def _monkey_write(self, original):
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun(cls, *args, **kwargs):
             db = getattr(cls, 'using', 'default')
             from django.db.models.sql import compiler
@@ -487,7 +484,7 @@ class QueryCacheBackend11(QueryCacheBackend):
         from django.db.models.sql.constants import MULTI
         from django.db.models.sql.datastructures import EmptyResultSet
 
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun(cls, result_type=MULTI):
             try:
                 sql, params = cls.as_sql()

--- a/johnny/decorators.py
+++ b/johnny/decorators.py
@@ -1,0 +1,12 @@
+try:
+    from functools import wraps, WRAPPER_ASSIGNMENTS
+except ImportError:
+    from django.utils.functional import wraps, WRAPPER_ASSIGNMENTS
+
+
+def available_attrs(fn):
+    """
+    Return the list of functools-wrappable attributes on a callable.
+    This is required as a workaround for http://bugs.python.org/issue3445.
+    """
+    return tuple(a for a in WRAPPER_ASSIGNMENTS if hasattr(fn, a))

--- a/johnny/tests/base.py
+++ b/johnny/tests/base.py
@@ -4,7 +4,6 @@
 """Base test class for Johnny Cache Tests."""
 
 import sys
-from django.utils.functional import wraps
 
 import django
 from django.test import TestCase, TransactionTestCase
@@ -13,6 +12,7 @@ from django.core.management import call_command
 from django.db.models.loading import load_app
 
 from johnny import settings as johnny_settings
+from johnny.decorators import wraps, available_attrs
 
 # order matters here;  I guess we aren't deferring foreign key checking :\
 johnny_fixtures = ['authors.json', 'genres.json', 'publishers.json', 'books.json']
@@ -29,7 +29,7 @@ def show_johnny_signals(hit=None, miss=None):
     hit = hit or _hit
     miss = miss or _miss
     def deco(func):
-        @wraps(func)
+        @wraps(func, assigned=available_attrs(func))
         def wrapped(*args, **kwargs):
             from johnny.signals import qc_hit, qc_miss
             qc_hit.connect(hit)

--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -6,10 +6,7 @@ try:
 except:
     DEFUALT_DB_ALIAS = None
 
-try:
-    from functools import wraps
-except ImportError:
-    from django.utils.functional import wraps  # Python 2.3, 2.4 fallback.
+from johnny.decorators import wraps, available_attrs
 
 
 class TransactionManager(object):
@@ -141,13 +138,13 @@ class TransactionManager(object):
         self._clear_sid_stack(using)
 
     def _patched(self, original, commit=True):
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun(using=None):
             #1.2 version
             original(using=using)
             self._flush(commit=commit, using=using)
 
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun11():
             #1.1 version
             original()
@@ -164,7 +161,7 @@ class TransactionManager(object):
 
     def _sid_key(self, sid, using=None):
         if using is not None:
-            prefix = 'trans_savepoint_%s'%using
+            prefix = 'trans_savepoint_%s' % using
         else:
             prefix = 'trans_savepoint'
 
@@ -261,7 +258,7 @@ class TransactionManager(object):
         del self.local[backup]
 
     def _savepoint(self, original):
-        @wraps(original)
+        @wraps(original, assigned=available_attrs(original))
         def newfun(using=None):
             if using != None:
                 sid = original(using=using)

--- a/johnny/utils.py
+++ b/johnny/utils.py
@@ -3,14 +3,12 @@
 
 """Extra johnny utilities."""
 
-try:
-    from functools import wraps
-except ImportError:
-    from django.utils.functional import wraps
-
 from johnny.cache import get_backend, local, patch, unpatch
+from johnny.decorators import wraps, available_attrs
+
 
 __all__ = ["celery_enable_all", "celery_task_wrapper", "johnny_task_wrapper"]
+
 
 def prerun_handler(*args, **kwargs):
     """Celery pre-run handler.  Enables johnny-cache."""
@@ -37,7 +35,7 @@ def celery_task_wrapper(f):
     """
     from celery.utils import fun_takes_kwargs
 
-    @wraps(f)
+    @wraps(f, assigned=available_attrs(f))
     def newf(*args, **kwargs):
         backend = get_backend()
         was_patched = backend._patched


### PR DESCRIPTION
This should prevent a bug when multiple monkey patching happens of the 
transaction modulee, e.g. when using django-celery-transactions.
