### PR TITLE
Adds FailSilentlyMemcachedCache

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -11,6 +11,7 @@ memcached
 .. automodule:: johnny.backends.memcached
 .. autoclass:: johnny.backends.memcached.MemcachedCache
 .. autoclass:: johnny.backends.memcached.PyLibMCCache
+.. autoclass:: johnny.backends.memcached.FailSilentlyMemcachedCache
 
 locmem
 ~~~~~~


### PR DESCRIPTION
I noticed that if you try to store something into the cache which is bigger that the max size allowed by memcached, it raise an exception, which will make your entire site to break.

This manager gives the user the chance to "ignore" that failure, which will give him the chance to keep working even if that queryset didn't get into the cache for some reason.
