### PR TITLE
Fix transaction breakage in Django 1.6

### DIFF
--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -137,7 +137,7 @@ class TransactionManager(object):
         else:
             prefix = 'trans_savepoint'
 
-        if sid.startswith(prefix):
+        if sid is not None and sid.startswith(prefix):
             return sid
         return '%s_%s'%(prefix, sid)
 


### PR DESCRIPTION
AttributeError: 'NoneType' object has no attribute 'startswith'
sid happens to be None in one or more cases, just test it's not None before returning it.
