### PR TITLE
Fix double delete by ignoring the problem.

### DIFF
--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -190,7 +190,7 @@ class TransactionManager(object):
                 stack.insert(0, popped)
             self._store_dirty(using)
             for i in stack:
-                for k, v in self.local[i].iteritems():
+                for k, v in self.local.get(i, {}).iteritems():
                     self.local[k] = v
                 del self.local[i]
             self._restore_dirty(using)


### PR DESCRIPTION
As described in the issues 69 of the BitBucket clone (https://bitbucket.org/jmoiron/johnny-cache/issue/69/keyerror-on-some-transactions), there seem to be situations in which the same savepoint ID can be allocated more than once. This causes a `KeError` when committing a savepoint.

A simple (naive) solution is to ignore savepoints that have already been "processed". This matches the effect of some of the suggestions in the aforementioned thread. Not sure that it's the best approach but it is easy.
