### PR TITLE
Transaction savepoint creation failure - issue 69 on bitbucket

### DIFF
--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -156,7 +156,8 @@ class TransactionManager(object):
         self._clear(using)
         #append the key to the savepoint stack
         sids = self._get_sid(using)
-        sids.append(key)
+        if len(sids) > 0 and sids[-1] != key:
+            sids.append(key)
 
     def _rollback_savepoint(self, sid, using=None):
         sids = self._get_sid(using)


### PR DESCRIPTION
Ran in to the error documented over at https://bitbucket.org/jmoiron/johnny-cache/issue/69/keyerror-on-some-transactions

This patch is the documented fix there and it works for us. Any possible fall out from this? Worthy of a merge?
