### PR TITLE
Fixed bug in LocalStoreClearMiddleware.process_exception

### DIFF
--- a/johnny/middleware.py
+++ b/johnny/middleware.py
@@ -42,7 +42,6 @@ class LocalStoreClearMiddleware(object):
     """
     def process_exception(self, *args, **kwargs):
         cache.local.clear()
-        raise
 
     def process_response(self, req, resp):
         cache.local.clear()


### PR DESCRIPTION
Hi there. This bug caused our production site being down so I decided to notify you about it.

According to [Django documentation on middleware methods](https://docs.djangoproject.com/en/dev/topics/http/middleware/#process_exception) the _process_exception_ method should not re-raise exception ever. Re-raising exception causes an error in middleware calls chain.

TL;DR: _process_exception_ should not raise any exceptions or return anything except of response (if any).
