### PR TITLE
Fixed bug that caused KeyError in _commit_all_savepoints

### DIFF
--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -126,7 +126,7 @@ class TransactionManager(object):
             original(using=using)
             # copying behavior of original func
             # if it is an 'unless_managed' version we should do nothing is transaction is managed
-            if not unless_managed or not django_transaction.is_managed():
+            if not unless_managed or not self.is_managed(using=using):
                 self._flush(commit=commit, using=using)
 
         return newfun

--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -125,7 +125,7 @@ class TransactionManager(object):
             #1.2 version
             original(using=using)
             # copying behavior of original func
-            # if it is an 'unless_managed' version we should do nothing is transaction is managed
+            # if it is an 'unless_managed' version we should do nothing if transaction is managed
             if not unless_managed or not self.is_managed(using=using):
                 self._flush(commit=commit, using=using)
 

--- a/johnny/transaction.py
+++ b/johnny/transaction.py
@@ -119,12 +119,15 @@ class TransactionManager(object):
         self._clear(using)
         self._clear_sid_stack(using)
 
-    def _patched(self, original, commit=True):
+    def _patched(self, original, commit=True, unless_managed=False):
         @wraps(original, assigned=available_attrs(original))
         def newfun(using=None):
             #1.2 version
             original(using=using)
-            self._flush(commit=commit, using=using)
+            # copying behavior of original func
+            # if it is an 'unless_managed' version we should do nothing is transaction is managed
+            if not unless_managed or not django_transaction.is_managed():
+                self._flush(commit=commit, using=using)
 
         return newfun
 
@@ -269,12 +272,18 @@ class TransactionManager(object):
         """
         if not self._patched_var:
             self._originals['rollback'] = self._getreal('rollback')
+            self._originals['rollback_unless_managed'] = self._getreal('rollback_unless_managed')
             self._originals['commit'] = self._getreal('commit')
+            self._originals['commit_unless_managed'] = self._getreal('commit_unless_managed')
             self._originals['savepoint'] = self._getreal('savepoint')
             self._originals['savepoint_rollback'] = self._getreal('savepoint_rollback')
             self._originals['savepoint_commit'] = self._getreal('savepoint_commit')
             django_transaction.rollback = self._patched(django_transaction.rollback, False)
+            django_transaction.rollback_unless_managed = self._patched(django_transaction.rollback_unless_managed,
+                                                                       False, unless_managed=True)
             django_transaction.commit = self._patched(django_transaction.commit, True)
+            django_transaction.commit_unless_managed = self._patched(django_transaction.commit_unless_managed,
+                                                                     True, unless_managed=True)
             django_transaction.savepoint = self._savepoint(django_transaction.savepoint)
             django_transaction.savepoint_rollback = self._savepoint_rollback(django_transaction.savepoint_rollback)
             django_transaction.savepoint_commit = self._savepoint_commit(django_transaction.savepoint_commit)


### PR DESCRIPTION
Fixed bug that caused KeyError in johnny.transaction.TransactionManager._commit_all_savepoints - issues #26 and #30 on Github ([#69](https://bitbucket.org/jmoiron/johnny-cache/issue/69/keyerror-on-some-transactions) on Bitbucket)

This patch is fixing cause of the problem, not hiding it as pull requests #26 and #30.

To reproduce cause of the problem you should:
1) Enable _QueryCacheMiddleware_
2) Work in unmanaged transaction state (it means autocommit mode, i.e. without _django.middleware.transaction.TransactionMiddleware_ and not within _transaction.enter_transaction_management()_ block)
3) Create a savepoint and then try to save some object (it is done by _django.db.models.query.QuerySet#get_or_create_ or by _django.contrib.sessions.backends.db.SessionStore#save_)

The essence of the problem is the fact that Django ORM widely uses a _django/db/transaction.py#commit_unless_managed_ (which is **unpatched** by Johny Cache) function instead of _django/db/transaction.py#commit_ (which is **patched** by Johny Cache). So, when we working in unmanaged transaction state Johny Cache will still register savepoints upon creation but will be unable to handle commits and rollbacks that wast performed by 'unless_managed' functions. Since Django is using dumb algorithm for savepoint names generation (they reuse same names within thread once they were commited) it will lead to a situation when Johny Cache will register several savepoints with same name within one transaction and fail when it will try to commit or rollback them.

Proposed solution adds patching to _django/db/transaction.py#commit_unless_managed_ and _django/db/transaction.py#rollback_unless_managed_ functions in the same way as it was done for _django/db/transaction.py#commit_ and _django/db/transaction.py#rollback_ functions with one difference - additional check whether current transaction is unmanaged.
