### PR TITLE
Tests for bugfixes provided in PRs # 33 and #34

### DIFF
--- a/johnny/tests/base.py
+++ b/johnny/tests/base.py
@@ -136,9 +136,8 @@ class message_queue(object):
 def supports_transactions(con):
     """A convenience function which will work across multiple django versions
     that checks whether or not a connection supports transactions."""
-    vendor = con.vendor
     if getattr(con.features, "supports_transactions", False):
-        if vendor == "mysql" and not getattr(con.features, '_storage_engine', '') == "InnoDB":
+        if con.vendor == "mysql" and not getattr(con.features, '_storage_engine', '') == "InnoDB":
             print "MySQL connection reports transactions supported but storage engine != InnoDB."
             return False
         return True

--- a/johnny/tests/base.py
+++ b/johnny/tests/base.py
@@ -136,10 +136,9 @@ class message_queue(object):
 def supports_transactions(con):
     """A convenience function which will work across multiple django versions
     that checks whether or not a connection supports transactions."""
-    features = con.features.__dict__
     vendor = con.vendor
-    if features.get("supports_transactions", False):
-        if vendor == "mysql" and not features.get('_storage_engine', '') == "InnoDB":
+    if getattr(con.features, "supports_transactions", False):
+        if vendor == "mysql" and not getattr(con.features, '_storage_engine', '') == "InnoDB":
             print "MySQL connection reports transactions supported but storage engine != InnoDB."
             return False
         return True

--- a/johnny/tests/cache.py
+++ b/johnny/tests/cache.py
@@ -104,13 +104,6 @@ class MultiDbTest(TransactionQueryCacheBase):
         t.start()
         t.join()
 
-    def _other(self, cmd, q):
-        def _innter(cmd):
-            q.put(eval(cmd))
-        t = Thread(target=_inner, args=(cmd,))
-        t.start()
-        t.join()
-
     def test_basic_queries(self):
         """Tests basic queries and that the cache is working for multiple db's"""
         if len(getattr(settings, "DATABASES", [])) <= 1:
@@ -208,7 +201,7 @@ class MultiDbTest(TransactionQueryCacheBase):
         from testapp.models import Genre
 
 
-        # sanity check 
+        # sanity check
         self.failUnless(transaction.is_managed() == False)
         self.failUnless(transaction.is_dirty() == False)
         self.failUnless("default" in getattr(settings, "DATABASES"))
@@ -229,7 +222,7 @@ class MultiDbTest(TransactionQueryCacheBase):
         g1.save()
         g2.save()
 
-        # test outside of transaction, should be cache hit and 
+        # test outside of transaction, should be cache hit and
         # not contain the local changes
         other("Genre.objects.using('default').get(pk=1)")
         hit, ostart = q.get()
@@ -294,7 +287,7 @@ class MultiDbTest(TransactionQueryCacheBase):
                     print "\n  Skipping test requiring savepoints."
                     return
 
-        # sanity check 
+        # sanity check
         self.failUnless(transaction.is_managed() == False)
         self.failUnless(transaction.is_dirty() == False)
         self.failUnless("default" in getattr(settings, "DATABASES"))
@@ -339,7 +332,7 @@ class MultiDbTest(TransactionQueryCacheBase):
         self.failUnless(g2.title == "Committed savepoint")
         transaction.savepoint_commit(sid2, using="second")
 
-        #other thread should still see original version even 
+        #other thread should still see original version even
         #after savepoint commit
         other("Genre.objects.using('second').get(pk=1)")
         hit, ostart = q.get()
@@ -615,7 +608,7 @@ class MultiModelTest(QueryCacheBase):
         #can't determine the queries here, 1.1 and 1.2 uses them differently
 
         connection.queries = []
-        #many to many should be invalidated, 
+        #many to many should be invalidated,
         #person is not invalidated since we just want
         #the many to many table to be
         p1 = Person.objects.get(pk=1)
@@ -707,7 +700,7 @@ class TransactionSupportTest(TransactionQueryCacheBase):
             queue.put(msg)
             if connections is not None:
                 #this is to fix a race condition with the
-                #thread to ensure that we close it before 
+                #thread to ensure that we close it before
                 #the next test runs
                 connections['default'].close()
         t = Thread(target=_inner, args=(query,))
@@ -924,7 +917,7 @@ class TransactionManagerTestCase(base.TransactionJohnnyTestCase):
 
     def setUp(self):
         self.middleware = middleware.QueryCacheMiddleware()
-    
+
     def tearDown(self):
         from django.db import transaction
         if transaction.is_managed():
@@ -944,9 +937,9 @@ class TransactionManagerTestCase(base.TransactionJohnnyTestCase):
         cache_backend.patch()
         keyhandler = cache_backend.keyhandler
         keygen = keyhandler.keygen
-        
+
         tm = cache_backend.cache_backend
-        
+
         # First, we set one key-val pair generated for our non-existing table.
         table_key = keygen.gen_table_key(TABLE_NAME)
         tm.set(table_key, 'val1')
@@ -954,7 +947,7 @@ class TransactionManagerTestCase(base.TransactionJohnnyTestCase):
         # Then we create a savepoint.
         # The key-value pair is moved into 'trans_sids' item of localstore.
         tm._create_savepoint('savepoint1')
-        
+
         # We then commit all the savepoints (i.e. only one in this case)
         # The items stored in 'trans_sids' should be moved back to the
         # top-level dictionary of our localstore


### PR DESCRIPTION
Includes:
1) 2 new tests;
2) Bugfix for 'johnny.tests.base.py#supports_transactions' function;
3) Removed unused & broken method 'johnny.tests.cache.MultiDbTest#_other'
4) Removed trailing spaces in test files
