### PR TITLE
Never cache the South migrations table.

### DIFF
--- a/johnny/settings.py
+++ b/johnny/settings.py
@@ -6,8 +6,10 @@ from django.core.cache import get_cache, cache
 
 DISABLE_QUERYSET_CACHE = getattr(settings, 'DISABLE_QUERYSET_CACHE', False)
 
+DEFAULT_BLACKLIST = ['south_migrationhistory']
+
 BLACKLIST = getattr(settings, 'MAN_IN_BLACKLIST',
-            getattr(settings, 'JOHNNY_TABLE_BLACKLIST', []))
+            getattr(settings, 'JOHNNY_TABLE_BLACKLIST', [])) + DEFAULT_BLACKLIST
 BLACKLIST = set(BLACKLIST)
 
 WHITELIST = set(getattr(settings, 'JOHNNY_TABLE_WHITELIST', []))


### PR DESCRIPTION
This can be extremely confusing during local development, where the
developer may recreate their database but johnny-cache still has stale
copies of the migrations.

Fixes https://github.com/jmoiron/johnny-cache/issues/47 .
