### PR TITLE
Don't return the wrong cached value if parameters happen to be prefixes

### DIFF
--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -177,6 +177,21 @@ class KeyGen(object):
         return '%s_%s_multi_%s' % (self.prefix, db, self.gen_key(*values))
 
     @staticmethod
+    def _add_separator(iterable, separator):
+        """Given an iterable, return a generator where every value is
+        separated by the separator given.
+
+        >>> list(KeyGen._add_separator([1, 2, 3], 0))
+        [1, 0, 2, 0, 3]
+
+        """
+        it = iter(iterable)
+        yield next(it)
+        for item in it:
+            yield separator
+            yield item
+
+    @staticmethod
     def _convert(x):
         if isinstance(x, unicode):
             return x.encode('utf-8')
@@ -196,7 +211,7 @@ class KeyGen(object):
         """Generate a key from one or more values."""
         key = md5()
 
-        for item in KeyGen._flatten(values):
+        for item in KeyGen._add_separator(KeyGen._flatten(values), "S"):
             key.update(KeyGen._convert(item))
         
         return key.hexdigest()

--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -183,17 +183,22 @@ class KeyGen(object):
         return str(x)
 
     @staticmethod
-    def _recursive_convert(x, key):
-        for item in x:
+    def _flatten(nested_list):
+        """Return a generator where nested lists or tuples are flattened."""
+        for item in nested_list:
             if isinstance(item, (tuple, list)):
-                KeyGen._recursive_convert(item, key)
+                for subitem in KeyGen._flatten(item):
+                    yield subitem
             else:
-                key.update(KeyGen._convert(item))
+                yield item
 
     def gen_key(self, *values):
         """Generate a key from one or more values."""
         key = md5()
-        KeyGen._recursive_convert(values, key)
+
+        for item in KeyGen._flatten(values):
+            key.update(KeyGen._convert(item))
+        
         return key.hexdigest()
 
 

--- a/johnny/tests/cache.py
+++ b/johnny/tests/cache.py
@@ -23,7 +23,9 @@ except NameError:
         return False
 
 # put tests in here to be included in the testing suite
-__all__ = ['MultiDbTest', 'SingleModelTest', 'MultiModelTest', 'TransactionSupportTest', 'BlackListTest', 'TransactionManagerTestCase']
+__all__ = ['MultiDbTest', 'SingleModelTest', 'MultiModelTest',
+           'TransactionSupportTest', 'BlackListTest',
+           'TransactionManagerTestCase', 'PrefixParamsTestCase']
 
 def _pre_setup(self):
     self.saved_DISABLE_SETTING = getattr(johnny_settings, 'DISABLE_QUERYSET_CACHE', False)
@@ -961,3 +963,20 @@ class TransactionManagerTestCase(base.TransactionJohnnyTestCase):
         tm._commit_all_savepoints()
         # And this checks if it actually happened.
         self.failUnless(table_key in tm.local)
+
+
+class PrefixParamsTestCase(QueryCacheBase):
+    def test_params_prefixes(self):
+        """Ensure we don't return incorrect results when queryset parameters
+        happen to concatenate to the correct value.
+
+        """
+        from testapp.models import User
+
+        User.objects.create(first_name="foo", last_name="bar")
+        User.objects.create(first_name="foob", last_name="ar")
+
+        u1 = User.objects.get(first_name="foo", last_name="bar")
+        u2 = User.objects.get(first_name="foob", last_name="ar")
+
+        self.assertNotEqual(u1, u2)


### PR DESCRIPTION
Johnny Cache builds a cache key by repeatedly calling `key.update`. This is equivalent to concatenating all the parameters together and generating a hash.

As a result, Johnny Cache confuses the following queries:

```
Foo.objects.get(x="foo", y="bar")
Foo.objects.get(x="foob", y="ar")

Bar.objects.get(x=1, y=21)
Bar.objects.get(x=12, y=1)
```

This pull request inserts a separator between parameters, so we don't get confused. This code is heavily based on the patch written by @milos-u.
