### PR TITLE
When either MAN_IN_BLACKLIST or JOHNNY_TABLE_BLACKLIST is a tuple django crashes.

### DIFF
--- a/johnny/settings.py
+++ b/johnny/settings.py
@@ -7,8 +7,8 @@ DISABLE_QUERYSET_CACHE = getattr(settings, 'DISABLE_QUERYSET_CACHE', False)
 
 DEFAULT_BLACKLIST = ['south_migrationhistory']
 
-BLACKLIST = getattr(settings, 'MAN_IN_BLACKLIST',
-            getattr(settings, 'JOHNNY_TABLE_BLACKLIST', [])) + DEFAULT_BLACKLIST
+BLACKLIST = list(getattr(settings, 'MAN_IN_BLACKLIST',
+            getattr(settings, 'JOHNNY_TABLE_BLACKLIST', []))) + DEFAULT_BLACKLIST
 BLACKLIST = set(BLACKLIST)
 
 WHITELIST = set(getattr(settings, 'JOHNNY_TABLE_WHITELIST', []))


### PR DESCRIPTION
Since it's concatenated to a list, so casting it to a list.
