### PR TITLE
Add option for disabling cache on COUNT queries.

### DIFF
--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -373,8 +373,9 @@ class QueryCacheBackend(object):
                 #no longer lazy...
                 #todo - create a smart iterable wrapper
                 val = list(val)
-            #if COUNT cache is disabled and this is a COUNT, don't check the cache.
-            if key is not None and not (settings.DISABLE_COUNT_CACHE and self.is_count(sql)):
+            #if COUNT cache is disabled, this is a query with `COUNT` in it, and `val` is a number,
+            #don't touch the cache.
+            if key is not None and not (settings.DISABLE_COUNT_CACHE and self.is_count(sql)) and not (val and type(val) == list and type(val[0]) in (long, int)):
                 if not val:
                     self.cache_backend.set(key, no_result_sentinel, settings.MIDDLEWARE_SECONDS, db)
                 else:

--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -299,6 +299,11 @@ class QueryCacheBackend(object):
                                             self.kg_class, self.prefix)
         self._patched = getattr(self, '_patched', False)
 
+    def is_count(self, sql):
+        if "COUNT" in sql:
+            return True
+        return False
+
     def _monkey_select(self, original):
         from django.db.models.sql.constants import MULTI
         from django.db.models.sql.datastructures import EmptyResultSet
@@ -368,7 +373,8 @@ class QueryCacheBackend(object):
                 #no longer lazy...
                 #todo - create a smart iterable wrapper
                 val = list(val)
-            if key is not None:
+            #if COUNT cache is disabled and this is a COUNT, don't check the cache.
+            if key is not None and not (settings.DISABLE_COUNT_CACHE and self.is_count(sql)):
                 if not val:
                     self.cache_backend.set(key, no_result_sentinel, settings.MIDDLEWARE_SECONDS, db)
                 else:

--- a/johnny/settings.py
+++ b/johnny/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.cache import get_cache, cache
 
 DISABLE_QUERYSET_CACHE = getattr(settings, 'DISABLE_QUERYSET_CACHE', False)
+DISABLE_COUNT_CACHE = getattr(settings, 'JOHNNY_DISABLE_COUNT_CACHE', False)
 
 DEFAULT_BLACKLIST = ['south_migrationhistory']
 


### PR DESCRIPTION
closes #57

I've added a setting to allow developers to disable caching on COUNT queries.
