### PR TITLE
Added testing compatibility with Oracle's mysql-connector-python (and other backends not packaged within Django)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
 install:
   - pip install Django==$DJANGO psycopg2==$PSYCOPG2 coveralls --use-mirrors
   - pip install -e git+https://github.com/niwibe/django-redis@$DJANGO_REDIS#egg=django-redis
+  - pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip#egg=mysql
   - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]
        || [[ $TRAVIS_PYTHON_VERSION == 3.3 ]];
     then
@@ -37,23 +38,33 @@ before_script:
   - mysql -e 'CREATE DATABASE johnny2_db;'
 
 script:
+  # Run against all database and cache backends, accumulating coverage stats.
   - CACHE_BACKEND=memcached
     coverage run --source=johnny manage.py test --traceback
-
   - CACHE_BACKEND=redis
     coverage run -a --source=johnny manage.py test --traceback
 
-  - DB_ENGINE=postgresql_psycopg2 CACHE_BACKEND=memcached
+  - DB_ENGINE=django.db.backends.postgresql_psycopg2 CACHE_BACKEND=memcached
+    coverage run -a --source=johnny manage.py test --traceback
+  - DB_ENGINE=django.db.backends.postgresql_psycopg2 CACHE_BACKEND=redis
     coverage run -a --source=johnny manage.py test --traceback
 
-  - DB_ENGINE=postgresql_psycopg2 CACHE_BACKEND=redis
+  - DB_ENGINE=django.db.backends.mysql CACHE_BACKEND=memcached
+    coverage run -a --source=johnny manage.py test --traceback
+  - DB_ENGINE=django.db.backends.mysql CACHE_BACKEND=redis
     coverage run -a --source=johnny manage.py test --traceback
 
-  - DB_ENGINE=mysql CACHE_BACKEND=memcached
-    coverage run -a --source=johnny manage.py test --traceback
+  # Only run mysql-connector on Python 3 for now since it fails with many
+  # string-encoding errors when tested on Python 2.
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
+        DB_ENGINE=mysql.connector.django CACHE_BACKEND=memcached
+        coverage run -a --source=johnny manage.py test --traceback
+    ; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]]; then
+        DB_ENGINE=mysql.connector.django CACHE_BACKEND=redis
+        coverage run -a --source=johnny manage.py test --traceback
+    ; fi
 
-  - DB_ENGINE=mysql CACHE_BACKEND=redis
-    coverage run -a --source=johnny manage.py test --traceback
 
 after_success:
   - coveralls

--- a/johnny/tests/base.py
+++ b/johnny/tests/base.py
@@ -10,7 +10,6 @@ from django.test import TestCase, TransactionTestCase
 from django.conf import settings
 from django.core.management import call_command
 from django.db.models.loading import load_app
-from django.utils import six
 
 from johnny import settings as johnny_settings
 from johnny.compat import Queue
@@ -133,7 +132,7 @@ def supports_transactions(con):
     if features.supports_transactions:
         if vendor == 'mysql':
             engine = getattr(features, '_mysql_storage_engine', '')
-            if not isinstance(engine, six.string_types):
+            if callable(engine):
                 # Oracle's mysql.connector.django backend uses a method call
                 # instead of a property.
                 engine = engine()

--- a/settings.py
+++ b/settings.py
@@ -11,15 +11,15 @@ ADMINS = ()
 
 MANAGERS = ADMINS
 
-db_engine = os.environ.get('DB_ENGINE', 'sqlite3')
+db_engine = os.environ.get('DB_ENGINE', 'django.db.backends.sqlite3')
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.' + db_engine,
+        'ENGINE': db_engine,
         'NAME': 'johnny_db',
         'TEST_NAME': 'test_johnny_db',
     },
     'second': {
-        'ENGINE': 'django.db.backends.' + db_engine,
+        'ENGINE': db_engine,
         'NAME': 'johnny2_db',
         'TEST_NAME': 'test_johnny2_db',
     },

--- a/settings.py
+++ b/settings.py
@@ -17,16 +17,27 @@ DATABASES = {
         'ENGINE': db_engine,
         'NAME': 'johnny_db',
         'TEST_NAME': 'test_johnny_db',
+        'OPTIONS': {},
     },
     'second': {
         'ENGINE': db_engine,
         'NAME': 'johnny2_db',
         'TEST_NAME': 'test_johnny2_db',
+        'OPTIONS': {},
     },
 }
-if db_engine == 'postgresql_psycopg2':
+if db_engine == 'django.db.backends.postgresql_psycopg2':
     DATABASES['default']['OPTIONS'] = {'autocommit': True}
     DATABASES['second']['OPTIONS'] = {'autocommit': True}
+if db_engine in ('django.db.backends.mysql', 'mysql.connector.django'):
+    DATABASES['default']['USER'] = 'root'
+    DATABASES['second']['USER'] = 'root'
+if db_engine == 'mysql.connector.django':
+    # Disable raising exception on database warnings (turned on by default
+    # when settings.DEBUG is True), otherwise causes test failures when trying
+    # to test for transaction support via use of a DROP TABLE IF EXISTS query.
+    DATABASES['default']['OPTIONS']['raise_on_warnings'] = False
+    DATABASES['second']['OPTIONS']['raise_on_warnings'] = False
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name


### PR DESCRIPTION
Updated the settings module used during testing to take full dotted path, for testing backends not included within Django.  Also added mysql engine detection for mysql-connector's use of a method instead of  a property.
