### PR TITLE
Travis CI version bumps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,16 @@ env:
   - DJANGO=1.6.5  PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
 
 install:
-  - pip install Django==$DJANGO psycopg2==$PSYCOPG2 coveralls --use-mirrors
+  - pip install Django==$DJANGO psycopg2==$PSYCOPG2 coveralls
   - pip install -e git+https://github.com/niwibe/django-redis@$DJANGO_REDIS#egg=django-redis
   - pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip#egg=mysql
   - if [[ $TRAVIS_PYTHON_VERSION == 3* ]];
     then
       pip install
         python3-memcached
-        -e git+https://github.com/clelland/MySQL-for-Python-3#egg=MySQL-python
-        --use-mirrors;
+        -e git+https://github.com/clelland/MySQL-for-Python-3#egg=MySQL-python;
     else
-      pip install python-memcached MySQL-python --use-mirrors;
+      pip install python-memcached MySQL-python;
     fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.2
   - 3.3
+  - 3.4
 
 services:
   - memcached
@@ -12,16 +13,15 @@ services:
 
 env:
   - DJANGO=1.3.7  PSYCOPG2=2.4.1 DJANGO_REDIS=a0806e34d1643887840cf3688933327b649c7a5a
-  - DJANGO=1.4.10 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
-  - DJANGO=1.5.5  PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
-  - DJANGO=1.6.2  PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+  - DJANGO=1.4.13 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+  - DJANGO=1.5.8  PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+  - DJANGO=1.6.5  PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
 
 install:
   - pip install Django==$DJANGO psycopg2==$PSYCOPG2 coveralls --use-mirrors
   - pip install -e git+https://github.com/niwibe/django-redis@$DJANGO_REDIS#egg=django-redis
   - pip install http://cdn.mysql.com/Downloads/Connector-Python/mysql-connector-python-1.2.2.zip#egg=mysql
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.2 ]]
-       || [[ $TRAVIS_PYTHON_VERSION == 3.3 ]];
+  - if [[ $TRAVIS_PYTHON_VERSION == 3* ]];
     then
       pip install
         python3-memcached
@@ -71,11 +71,16 @@ after_success:
 
 matrix:
   exclude:
+    # Django < 1.5 is not Python 3 compatible.
     - python: 3.2
       env: DJANGO=1.3.7  PSYCOPG2=2.4.1 DJANGO_REDIS=a0806e34d1643887840cf3688933327b649c7a5a
     - python: 3.3
       env: DJANGO=1.3.7  PSYCOPG2=2.4.1 DJANGO_REDIS=a0806e34d1643887840cf3688933327b649c7a5a
+    - python: 3.4
+      env: DJANGO=1.3.7  PSYCOPG2=2.4.1 DJANGO_REDIS=a0806e34d1643887840cf3688933327b649c7a5a
     - python: 3.2
-      env: DJANGO=1.4.10 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+      env: DJANGO=1.4.13 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
     - python: 3.3
-      env: DJANGO=1.4.10 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+      env: DJANGO=1.4.13 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4
+    - python: 3.4
+      env: DJANGO=1.4.13 PSYCOPG2=2.5.2 DJANGO_REDIS=3.4


### PR DESCRIPTION
Added Python 3.4, bumped Django versions, and removed use of deprecated --use-mirrors option.
