### PR TITLE
Use sets rather than lists when getting tables for query.

### DIFF
--- a/johnny/cache.py
+++ b/johnny/cache.py
@@ -123,7 +123,7 @@ def get_tables_for_query_pre_16(query):
     """
     from django.db.models.sql.where import WhereNode
     from django.db.models.query import QuerySet
-    tables = [v[0] for v in getattr(query,'alias_map',{}).values()]
+    tables = set([v[0] for v in getattr(query,'alias_map',{}).values()])
 
     def get_tables(node, tables):
         for child in node.children:
@@ -133,15 +133,15 @@ def get_tables_for_query_pre_16(query):
                 continue
             else:
                 for item in (c for c in child if isinstance(c, QuerySet)):
-                    tables += get_tables_for_query(item.query)
+                    tables |= set(get_tables_for_query(item.query))
         return tables
 
     if query.where and query.where.children:
         where_nodes = [c for c in query.where.children if isinstance(c, WhereNode)]
         for node in where_nodes:
-            tables += get_tables(node, tables)
+            tables |= get_tables(node, tables)
 
-    return list(set(tables))
+    return list(tables)
 
 
 if django.VERSION[:2] < (1, 6):


### PR DESCRIPTION
`johnny.cache.get_tables_for_query_pre_16`: use a set as the base tables collection before entering recursion, thus avoiding a MemoryError should the WHERE descendant list go too deep.

This fully fixes #45 by preventing the top-most table list from growing more than it has to by being a `set`.

We ran into this problem because we had a bug that built a bad query. The query was valid, but the app broke when `johnny-cache` was in use.
